### PR TITLE
Merging Reg-Free Com attributes

### DIFF
--- a/ClickOnce/Builders/ApplicationBuilder.cs
+++ b/ClickOnce/Builders/ApplicationBuilder.cs
@@ -197,15 +197,33 @@ namespace ClickOnce
             }
             else if (application.AssemblyReferences.FindTargetPath(target) is null 
                      && application.FileReferences.FindTargetPath(target) is null)
-            {
-                application.FileReferences.Add(new FileReference
+            {                
+                FileReference fileReference = new FileReference
                 {
                     SourcePath = source,
                     TargetPath = target,
                     IsDataFile = kind == GlobKind.DataFiles,
                     IsOptional = group != null,
                     Group = group
-                });
+                }
+                if(project.MergeCom.Value)
+                {
+                    string manifestFile = $"{source}.manifest";
+                    if(File.Exist(manifestFile))
+                    {
+                        Manifest manifest = ManifestReader.ReadManifest(manifestFile, false);
+                        if(manifest?.FileReferences?.Count > 0)
+                        {
+                            FileReference matchedFile = manifest.FileReferences[0];
+                            if (fileReference.TargetPath == matchedFile.TargetPath)
+                            {
+                                fileReference.XmlComClasses = matchedFile.ComClasses;                            
+                                fileReference.XmlTypeLibs = matchedFile.TypeLibs;
+                            }
+                        }
+                    }
+                }
+                application.FileReferences.Add(fileReference);
             }
             else
             {

--- a/ClickOnce/Builders/ApplicationBuilder.cs
+++ b/ClickOnce/Builders/ApplicationBuilder.cs
@@ -197,7 +197,7 @@ namespace ClickOnce
             }
             else if (application.AssemblyReferences.FindTargetPath(target) is null 
                      && application.FileReferences.FindTargetPath(target) is null)
-            {                
+            {
                 FileReference fileReference = new FileReference
                 {
                     SourcePath = source,
@@ -205,11 +205,11 @@ namespace ClickOnce
                     IsDataFile = kind == GlobKind.DataFiles,
                     IsOptional = group != null,
                     Group = group
-                }
+                };
                 if(project.MergeCom.Value)
                 {
                     string manifestFile = $"{source}.manifest";
-                    if(File.Exist(manifestFile))
+                    if(File.Exists(manifestFile))
                     {
                         Manifest manifest = ManifestReader.ReadManifest(manifestFile, false);
                         if(manifest?.FileReferences?.Count > 0)

--- a/ClickOnce/ClickOnce.csproj
+++ b/ClickOnce/ClickOnce.csproj
@@ -26,12 +26,12 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.7.82" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.3" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.28" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/ClickOnce/Command/Args/Args.cs
+++ b/ClickOnce/Command/Args/Args.cs
@@ -240,6 +240,11 @@ namespace ClickOnce
         private string fileAssociations;
         public static string Help_Arg_FileAssociations => GetHelpText();
 
+        [Option(SetName = "MergeCom", HelpText = nameof(Help_Arg_MergeCom), ResourceType = typeof(Args))]
+        public virtual bool? MergeCom { get => mergeCom; set => SetValue(value, ref mergeCom); }
+        private bool? mergeCom;
+        public static string Help_Arg_MergeCom => GetHelpText();
+
         [Option(HelpText = nameof(Help_Arg_UseApplicationTrust), ResourceType = typeof(Args))]
         public virtual bool? UseApplicationTrust { get => useApplicationTrust; set => SetValue(value, ref useApplicationTrust); }
         private bool? useApplicationTrust;

--- a/ClickOnce/Project/Project.cs
+++ b/ClickOnce/Project/Project.cs
@@ -53,7 +53,8 @@ namespace ClickOnce
         internal EnumOption<UseLauncher> UseLauncher => args.GetEnum<UseLauncher>();
         internal BooleanOption CreateDesktopShortcut => args.GetBoolean();
         internal BooleanOption CreateAutoRun => args.GetBoolean();
-        internal StringOption FileAssociations => args.GetString();
+        internal StringOption FileAssociations => args.GetString();        
+        internal BooleanOption MergeCom => args.GetBoolean();
         internal BooleanOption UseApplicationTrust => args.GetBoolean();
         internal TrustOption TrustInfo => args.GetTrust(SameSite.Value, Source.RootedPath);
         internal BooleanOption SameSite => args.GetBoolean();
@@ -62,7 +63,7 @@ namespace ClickOnce
         internal StringOption TimestampUrl => args.GetString();
         internal BooleanOption Quiet => args.GetBoolean();
         internal BooleanOption Verbose => args.GetBoolean();
-
+        
         internal void Validate()
         {
             if (!Directory.Exists(Source.Value))

--- a/ClickOnce/Resources/Messages.Designer.cs
+++ b/ClickOnce/Resources/Messages.Designer.cs
@@ -19,7 +19,7 @@ namespace ClickOnce.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Messages {
@@ -716,6 +716,24 @@ namespace ClickOnce.Resources {
         public static string Help_Arg_LaunchMode_Create {
             get {
                 return ResourceManager.GetString("Help.Arg.LaunchMode.Create", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Boolean. Merge comclass and typelib tags from Manifest files to be able to use Reg Free Com..
+        /// </summary>
+        public static string Help_Arg_MergeCom {
+            get {
+                return ResourceManager.GetString("Help.Arg.MergeCom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If not specified, defaults to false..
+        /// </summary>
+        public static string Help_Arg_MergeCom_Create {
+            get {
+                return ResourceManager.GetString("Help.Arg.MergeCom.Create", resourceCulture);
             }
         }
         

--- a/ClickOnce/Resources/Messages.resx
+++ b/ClickOnce/Resources/Messages.resx
@@ -240,6 +240,9 @@
   <data name="Help.Arg.TargetFramework.Create" xml:space="preserve">
     <value>If not specified, defaults to 'net472'.</value>
   </data>
+  <data name="Help.Arg.MergeCom" xml:space="preserve">
+    <value>Boolean. Merge comclass and typelib tags from Manifest files to be able to use Reg Free Com.</value>
+  </data>
   <data name="Help.Arg.Quiet" xml:space="preserve">
     <value>Boolean. Displays only minimal information when the ClickOnce package is built.</value>
   </data>
@@ -409,6 +412,9 @@ See license text for details (MIT)</value>
   </data>
   <data name="Help.Arg.OsSupportUrl.Constraint" xml:space="preserve">
     <value>Must be a valid and absolute URI (a URL or a UNC).</value>
+  </data>
+  <data name="Help.Arg.MergeCom.Create" xml:space="preserve">
+    <value>If not specified, defaults to false.</value>
   </data>
   <data name="Help.Arg.Quiet.Create" xml:space="preserve">
     <value>If not specified, defaults to false.</value>

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Copious arguments are available to take full control of manifest generation, lis
 | CreateDesktopShortcut | Boolean. Specifies whether a shortcut to the application should be added to the user's desktop'. Has no effect if LaunchMode is 'url'. If not specified, defaults to false. |
 | CreateAutoRun | Boolean. Specifies whether or not to create an autorun.inf to launch the ClickOnce installer when deployed to removable media. If not specified, defaults to false. |
 | UseApplicationTrust | Boolean. Specifies which manifest should be used for trust decisions. If true, the Product, Publisher, and SupportUrl properties are written to the application manifest; otherwise, they are written to the deployment manifest. If not specified, defaults to false. |
+| MergeCom | Boolean. Merge comclass and typelib tags from Manifest files to be able to use Reg Free Com. If not specified, defaults to false. |
 | Quiet | Boolean. Displays only minimal information when the ClickOnce package is built. If not specified, defaults to false. |
 | Verbose | Boolean. Displays extra information when the ClickOnce package is built. If not specified, defaults to false. |
 | Help | Display a help screen. |


### PR DESCRIPTION
this addresses  #16 and #23.
i did not added the MergeCom flag to the azure devops task.
i used detection of .manifest based on the file name.
it could be improved by searching for some extension like *.com.manifest and then match the file names from them with the existing targets in the manifest, which is what i do today after creating manifests with mt.exe.